### PR TITLE
ci: set the java version to 11

### DIFF
--- a/.github/workflows/manage-github-issue-for-outdated-dependencies.yml
+++ b/.github/workflows/manage-github-issue-for-outdated-dependencies.yml
@@ -11,6 +11,12 @@ jobs:
     name: Check outdated dependencies and create issue if it doesn't exist
     steps:
       - uses: actions/checkout@v3
+      
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+          cache: 'gradle'
 
       - name: Check outdated dependencies and create issue
         id: check-outdated-dependencies-and-create-issue


### PR DESCRIPTION
build was failing because github action is fetching the java version as 1.8

## Description of the change

> Description here

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
