### PR TITLE
Replace dashes with underscores in event key

### DIFF
--- a/firebase/src/main/java/com/rudderstack/android/integration/firebase/Utils.java
+++ b/firebase/src/main/java/com/rudderstack/android/integration/firebase/Utils.java
@@ -100,7 +100,7 @@ public class Utils {
     }
 
     static String getTrimKey(String key) {
-        String firebaseEvent = key.toLowerCase().trim().replace(" ", "_");
+        String firebaseEvent = key.toLowerCase().trim().replace(" ", "_").replace("-", "_");
         if (firebaseEvent.length() > 40) {
             firebaseEvent = firebaseEvent.substring(0, 40);
         }


### PR DESCRIPTION
Added replacement of dashes with underscores, like done with white spaces, because not allowed in Firebase event keys.

**Fixes** # (*issue*)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] Version upgraded (project, README, gradle, podspec etc)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
