### PR TITLE
ci: use shas for external github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: styfle/cancel-workflow-action@0.9.1
+      - uses: styfle/cancel-workflow-action@85880fa0301c86cca9da44039ee3bb12d3bedbfa #v0.12.1
         with:
           workflow_id: ${{ github.event.workflow.id }}
 
@@ -34,7 +34,7 @@ jobs:
         run: chmod +x gradlew
 
       - name: cache gradle dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/draft_new_release.yml
+++ b/.github/workflows/draft_new_release.yml
@@ -66,7 +66,7 @@ jobs:
           git push
 
       - name: Create pull request into master
-        uses: repo-sync/pull-request@v2
+        uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 # v2
         with:
           source_branch: ${{ steps.create-release.outputs.branch_name }}
           destination_branch: 'master'

--- a/.github/workflows/notion_pr_sync.yml
+++ b/.github/workflows/notion_pr_sync.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Sync Github PRs to Notion
-        uses: sivashanmukh/github-notion-pr-sync@1.0.0
+        uses: sivashanmukh/github-notion-pr-sync@3967330238449a8550b06f6e1d6b83e1af569876 #v1.0.0
         with:
           notionKey: ${{ secrets.NOTION_BOT_KEY }}
           notionDatabaseId: ${{ secrets.NOTION_PR_DB_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
         run: chmod +x gradlew
 
       - name: cache gradle dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/snapshot_release.yml
+++ b/.github/workflows/snapshot_release.yml
@@ -22,7 +22,7 @@ jobs:
         run: chmod +x gradlew
 
       - name: cache gradle dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches


### PR DESCRIPTION
**Fixes** # (*issue*)
* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L16-R16): Updated `styfle/cancel-workflow-action` to use a specific commit hash for version `v0.12.1` and upgraded `actions/cache` from `v3` to `v4`. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L16-R16) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L37-R37)
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L25-R25): Upgraded `actions/cache` from `v2` to `v4`.
* [`.github/workflows/snapshot_release.yml`](diffhunk://#diff-69397613f7f2a23faae50579930fcdb9ccda0e4c218eb7cb04a24115f9b872aeL25-R25): Upgraded `actions/cache` from `v2` to `v4`.
* * [`.github/workflows/draft_new_release.yml`](diffhunk://#diff-416c0e6aeb855dec6ffe340804676bcb1030d1868a6bc9a946e1264226b24edeL69-R69): Updated `repo-sync/pull-request` to use a specific commit hash for version `v2`.
* [`.github/workflows/notion_pr_sync.yml`](diffhunk://#diff-318e6599da19bc2d59182f0527cb1b62b4b65ab1357935d213d21940754764c7L51-R51): Updated `sivashanmukh/github-notion-pr-sync` to use a specific commit hash for version `v1.0.0`.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] Version upgraded (project, README, gradle, podspec etc)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
